### PR TITLE
Working basic denoising conditional CVAE on MNIST data

### DIFF
--- a/VAE.py
+++ b/VAE.py
@@ -4,6 +4,7 @@ from tensorflow import keras
 from tensorflow.keras import layers
 import matplotlib.pyplot as plt
 from tensorflow.keras.callbacks import TensorBoard
+from tensorflow.keras.utils import to_categorical
 from datetime import datetime
 
 # Creates noisy digits
@@ -25,6 +26,20 @@ x_test_noisy = x_test + noise_factor * np.random.normal(loc=0.0, scale=1.0, size
 x_train_noisy = np.clip(x_train_noisy, 0., 1.)
 x_test_noisy = np.clip(x_test_noisy, 0., 1.)
 
+# Our conditions will be the labels of the input digits.
+# We could perhaps just give the label itself here (divided
+# by num_classes in order to normalise):
+#y_train = y_train.astype('float32') / num_classes
+#y_test = y_test.astype('float32') / num_classes
+# However, these are categories, rather than a continuum,
+# so in this case it is probably more appropriate to use a set
+# of num_classes inputs, giving the probability that the label
+# belongs to each class (these will all be zero, except for one,
+# which will be one - a so-called "one hot" encoding).
+num_classes = 10
+y_train = to_categorical(y_train, num_classes)
+y_test = to_categorical(y_test, num_classes)
+
 # create a sampling layer
 
 class Sampling(layers.Layer):
@@ -42,25 +57,44 @@ class Sampling(layers.Layer):
 latent_dim = 2
 
 encoder_inputs = keras.Input(shape=(28, 28, 1))
+# We need another input for the labels.
+# If our condition were a continuous quantity, this could just be
+# that value, but here we have a set of categorical classes:
+condition_inputs = keras.Input(shape=(num_classes,))
 x = layers.Conv2D(32, 3, activation="relu", strides=2, padding="same")(encoder_inputs)
 x = layers.Conv2D(64, 3, activation="relu", strides=2, padding="same")(x)
 x = layers.Flatten()(x)
+# I suggest we try including the conditions here. This means they can
+# be processed (by a couple of fully-connected layers and one
+# non-linearity) in producing the latent encoding, but avoids some
+# complications of adding them in earlier. This is ok, because the
+# basic features that the network needs to learn should not depend
+# very strongly on the labels, but including them here should allow
+# our encoding to be more efficient representation of each class.
+x = layers.Concatenate()([x, condition_inputs])
 x = layers.Dense(16, activation="relu")(x)
 z_mean = layers.Dense(latent_dim, name="z_mean")(x)
 z_log_var = layers.Dense(latent_dim, name="z_log_var")(x)
 z = Sampling()([z_mean, z_log_var])
-encoder = keras.Model(encoder_inputs, [z_mean, z_log_var, z], name="encoder")
+encoder = keras.Model([encoder_inputs, condition_inputs], [z_mean, z_log_var, z], name="encoder")
 encoder.summary()    
 
 # build the decoder
 
 latent_inputs = keras.Input(shape=(latent_dim,))
-x = layers.Dense(7 * 7 * 64, activation="relu")(latent_inputs)
+# We add our conditions again here. One might think this is
+# unnecessary, as the latent encoding already contains this
+# information. However, I think including them here has two
+# advantages: (1) it means that the latent encoding does not need to
+# contain the condition, so can be more efficient, and (2) if we use
+# the decoder alone, we can specify the condition.
+x = layers.Concatenate()([latent_inputs, condition_inputs])
+x = layers.Dense(7 * 7 * 64, activation="relu")(x)
 x = layers.Reshape((7, 7, 64))(x)
 x = layers.Conv2DTranspose(64, 3, activation="relu", strides=2, padding="same")(x)
 x = layers.Conv2DTranspose(32, 3, activation="relu", strides=2, padding="same")(x)
 decoder_outputs = layers.Conv2DTranspose(1, 3, activation="sigmoid", padding="same")(x)
-decoder = keras.Model(latent_inputs, decoder_outputs, name="decoder")
+decoder = keras.Model([latent_inputs, condition_inputs], decoder_outputs, name="decoder")
 decoder.summary()
 
 # define the VAE model
@@ -74,8 +108,9 @@ beta = 1.0
 kl_loss = -0.5 * (1 + z_log_var - tf.square(z_mean) - tf.exp(z_log_var))
 kl_loss = beta * tf.reduce_mean(tf.reduce_sum(kl_loss, axis=1))
 
-vae_outputs = decoder(encoder(encoder_inputs)[-1])
-vae = keras.Model(encoder_inputs, vae_outputs)
+vae_outputs = decoder([encoder([encoder_inputs, condition_inputs])[-1],
+                       condition_inputs])
+vae = keras.Model([encoder_inputs, condition_inputs], vae_outputs)
 vae.add_loss(kl_loss)
 vae.add_metric(kl_loss, name='kl_loss')
 
@@ -87,16 +122,16 @@ vae.compile(optimizer=keras.optimizers.Adam(), loss=reconstruction_loss,
 logdir = "/tmp/tb/" + datetime.now().strftime("%Y%m%d-%H%M%S")
 tensorboard_callback = keras.callbacks.TensorBoard(log_dir=logdir)
 
-vae.fit(x_train_noisy, x_train,
-        epochs=60,
+vae.fit([x_train_noisy, y_train], x_train,
+        epochs=10,
         batch_size=128,
         shuffle=True,
-        validation_data=(x_test_noisy, x_test),
+        validation_data=([x_test_noisy, y_test], x_test),
         callbacks=[tensorboard_callback])
 
 # show what the original, noisy and reconstructed digits look like
 
-reconstructions = vae.predict(x_test_noisy)
+reconstructions = vae.predict([x_test_noisy, y_test])
 
 n = 10
 fig, axarr = plt.subplots(3, n, figsize=(20, 6))


### PR DESCRIPTION
This is based on the example Larissa found together with both my earlier intuitions and some further thinking about where to include the conditions in the network. Again, decent examples seem to be hard to find online. Maybe I should write a Medium article about the steps we are taking in developing this code!

I've extended the previous CVAE example to add in a condition: the label of the digit. I have included some comments in the code explaining my thought process, and how this MNIST example relates to our real goals (i.e. conditioning on a continuous quantity, redshift, rather than categories).

This is my first go at this, but it seems to work (based on very limited testing!). After just 10 epochs of training (loss still falling, should actually train for longer), with just 2 latent dimensions and beta=1, we get `loss: 32.9153 - reconstruction_loss: 29.9338 - kl_loss: 2.9880 - val_loss: 32.9985 - val_reconstruction_loss: 30.0675 - val_kl_loss: 2.9521` and [pretty good looking reconstructions](https://github.com/aidenrolfe/ARG/files/6058379/examples_latent2_beta1_epochs10.pdf).