### PR TITLE
Quick example of separating training and plotting

### DIFF
--- a/GalaxiesVAEplot.py
+++ b/GalaxiesVAEplot.py
@@ -1,0 +1,17 @@
+from GalaxiesVAE import *
+
+logname = '20210328-231422'
+
+vae.load_weights(f'weights_{logname}')
+
+if conditional:
+    reconstructions = vae.predict([gal_input_test, redshifts_test])
+    z_mean, z_log_var, z = encoder.predict([gal_input_test, redshifts_test])
+else:
+    reconstructions = vae.predict(gal_input_test)
+    z_mean, z_log_var, z = encoder.predict(gal_input_test)
+
+for i in range(10):
+    plot_example(gal_input_test, gal_target_test, reconstructions, redshifts_test,
+                 filename=f'example_{i}_{logname}.pdf')
+


### PR DESCRIPTION
I realised that it isn't obvious how to save the model and reload it for creating reconstructions later on. Here's an example. Note that loading a full saved model (saved with `save_model`) isn't easy to make work, so instead I've just saved the weights (with `save_weights`). Then, in `GalaxiesVAEplot.py`, I create the model again (by importing everything from `GalaxiesVAE.py`) and load the weights into it. To avoid re-running the training when the file is imported, I put the training code in an `if __name__ == "__main__"` block.

Note that loading the weights into the model requires that the architecture in GalaxiesVAE.py still match that of the saved weights. When you have a model you want to keep, it's therefore a good idea to record both the git commit id (first 7 characters is plenty) and log name (which is based on the date and time) so you know how they match up.

In this code I also switched back to doing the redshifting transformation from input to target with the redshift condition. I'll let you run it yourself. I look forward to seeing your results! I am available for a meeting tomorrow, if you are (sorry, I got my weeks mixed up).
