### PR TITLE
Update redshifting.py

### DIFF
--- a/redshifting.py
+++ b/redshifting.py
@@ -11,8 +11,8 @@ cosmo = FlatLambdaCDM(H0=70 * u.km / u.s / u.Mpc, Tcmb0=2.725 * u.K, Om0=0.3)
 
 
 def main():
-    scale = process('input')
-    process('target', scale)
+    process('input')
+    process('target')
 
 
 def process(name, scale=None, batchsize=1000):


### PR DESCRIPTION
`process` does not return (returns None) and so `scale` is always None, as written. Remove for clarity.